### PR TITLE
Fix file uppcase

### DIFF
--- a/src/components/Footer/component.js
+++ b/src/components/Footer/component.js
@@ -1,5 +1,5 @@
 // Include component
-import component from './footer.js';
+import component from './Footer.js';
 
 // Export
 export {

--- a/src/components/Menu/component.js
+++ b/src/components/Menu/component.js
@@ -1,5 +1,5 @@
 // Include component
-import component from './menu.js';
+import component from './Menu.js';
 
 // Export
 export {


### PR DESCRIPTION
components.Footer and components.Menu had the wrong casing for ./Footer.js and ./Menu.js. The both had lower case and it was causing a webpack build fail.