### PR TITLE
Single script for testing development, production

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2,9 +2,8 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link href="./bundle.css" rel="stylesheet">
-  </head>
+    <title>Webpack App</title>
+  <link href="./bundle.css" rel="stylesheet"></head>
   <body>
-    <script type="text/javascript" src="./bundle.js"></script>
-  </body>
+  <script type="text/javascript" src="./bundle.js"></script></body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
   "license": "MIT",
   "main": "main.js",
   "scripts": {
-    "testDev": "electron .",
-    "testProd": "electron . --noDevServer",
-    "dev": "webpack-dev-server --progress --hot --host 0.0.0.0 --config=./webpack.dev.config.js",
+    "dev": "webpack-dev-server --hot --host 0.0.0.0 --config=./webpack.dev.config.js",
+    "prod": "webpack --progress --config webpack.build.config.js && electron --noDevServer .",
     "build": "webpack --progress --config webpack.build.config.js",
     "package": "webpack --config webpack.build.config.js",
     "postpackage": "electron-packager ./ --out=./builds",

--- a/webpack.build.config.js
+++ b/webpack.build.config.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BabiliPlugin = require('babili-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -43,6 +44,7 @@ module.exports = {
   },
   target: 'electron-renderer',
   plugins: [
+    new HtmlWebpackPlugin(),
     new ExtractTextPlugin("bundle.css"),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production')

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { spawn } = require('child_process');
 
 // Config directories
 const SRC_DIR = path.resolve(__dirname, 'src');
@@ -56,6 +57,15 @@ module.exports = {
       colors: true,
       chunks: false,
       children: false
+    },
+    setup() {
+      spawn(
+        'electron',
+        ['.'],
+        { shell: true, env: process.env, stdio: 'inherit' }
+      )
+      .on('close', code => process.exit(0))
+      .on('error', spawnError => console.error(spawnError));
     }
   }
 };


### PR DESCRIPTION
Used `child_process.spawn` to spawn electron in `webpack.dev.config.js`, thus eliminating the need for two consoles and two separate scripts to run your development server and electron.

Also updated the `testProd` script to build and start electron in `--noDevServer` mode. To keep things consistent, changed the name of the script to `prod`.

End result:
`npm run dev` and `npm run prod` start the dev and production live tests, respectively.